### PR TITLE
S3 - Allow only mentioned Keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Version: **0.1.0**
 | config.rewrites | **map[string][string]** (*check `'config.rewrites' object`) | false | <pre>"/": "/index.html"</pre> |  |
 | config.host | **string** | false |  |  |
 | config.port | **integer** | false | <pre>443</pre> | <pre>- between:<br/>  - 0<br/>  - 65535</pre> |
+| config.keys | **array[string]** | false | | |
 
 ### 'config.rewrites' object
 
@@ -44,5 +45,6 @@ plugins:
     rewrites: {}
     host: ''
     port: 443
+    keys: ["random-file.txt"]
 ```
 <!-- END OF KONG-PLUGIN DOCS HOOK -->

--- a/kong/plugins/s3/access.lua
+++ b/kong/plugins/s3/access.lua
@@ -55,6 +55,23 @@ function _M.execute(conf)
   local host = (conf['host'] ~= nil) and conf['host'] or (bucket_name .. '.s3.amazonaws.com')
   local port = (conf['port'] ~= nil) and conf['port'] or 443
 
+  local keys = conf['keys']
+  if keys ~= nil then
+    local key = ngx.unescape_uri(bucket_key)
+    local key_contains = false
+
+    for _, v in pairs(keys) do
+      if v == key then
+        key_contains = true
+        break
+      end
+    end
+
+    if #keys > 0 and not key_contains then
+      return kong.response.exit(404)
+    end
+  end
+
   local opts = {
     region = conf.aws_region,
     service = 's3',

--- a/kong/plugins/s3/schema.lua
+++ b/kong/plugins/s3/schema.lua
@@ -49,6 +49,13 @@ return {
         } },
         { host = typedefs.host },
         { port = typedefs.port { default = 443 }, },
+        { keys = {
+          type = "array",
+          required = false,
+          elements = {
+            type = "string"
+          }
+        }}
       }
     },
   } },


### PR DESCRIPTION
Added support to allow only mentioned key(s) to get rather entire bucket. Still its an optional. 